### PR TITLE
Perftest: Add Pensando device support

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2134,6 +2134,8 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 0x1023 : dev_fname = YUNSILICON_DIAMOND_NEXT; break;
 			default     : dev_fname = YUNSILICON_ANDES; break;
 		}
+	} else if (attr.vendor_id == 0x1dd8) {
+		dev_fname = PENSANDO_ALL;
 	} else {
 
 		//coverity[uninit_use]

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -391,6 +391,7 @@ enum ctx_device {
 	YUNSILICON_ANDES	= 35,
 	YUNSILICON_DIAMOND	= 36,
 	YUNSILICON_DIAMOND_NEXT	= 37,
+	PENSANDO_ALL		= 38,
 };
 
 /* Units for rate limiter */


### PR DESCRIPTION
Adds the PENSANDO_ALL device (vendor_id 0x1dd8)